### PR TITLE
Update DbContextExtensions.cs

### DIFF
--- a/TrackableEntities.EF.Core/DbContextExtensions.cs
+++ b/TrackableEntities.EF.Core/DbContextExtensions.cs
@@ -234,6 +234,8 @@ namespace TrackableEntities.EF.Core
             if (entry.State == EntityState.Modified
                 && trackable.ModifiedProperties != null)
             {
+                //Set entity state to Unchanged
+                entry.State = EntityState.Unchanged;
                 foreach (var property in trackable.ModifiedProperties)
                     entry.Property(property).IsModified = true;
             }


### PR DESCRIPTION
this commit fixes #18

Made EntityEntry State to UnChanged. As soon as one of the property is modified, the state of the entity will also move to Modified. But only the properties we marked as modified will be updated when we save. I think this line was missing. Correct me if I am wrong!